### PR TITLE
Fix: Use phpunit as installed with composer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ before_install:
 install:
   - composer install --no-interaction --prefer-source
 
-script: phpunit --configuration ./phpunit.xml.dist
+script: vendor/bin/phpunit --configuration ./phpunit.xml.dist


### PR DESCRIPTION
This PR

* [x] uses `phpunit` as installed with `composer` rather than default installed on Travis