### PR TITLE
Fix: Cache dependencies installed with composer between builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,14 @@ matrix:
     - php: nightly
     - php: hhvm
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 before_install:
   - composer self-update
 
 install:
-  - composer install --no-interaction --prefer-source
+  - composer install --no-interaction --prefer-dist
 
 script: phpunit --configuration ./phpunit.xml.dist


### PR DESCRIPTION
This PR

* [x] caches dependencies installed with `composer` between builds on Travis

💁‍♂️ For reference, see https://docs.travis-ci.com/user/caching/#Arbitrary-directories.