### PR TITLE
Fix: Class name does not match project structure

### DIFF
--- a/tests/CriteriaBaseTest.php
+++ b/tests/CriteriaBaseTest.php
@@ -1,6 +1,7 @@
 <?php
-namespace Minimalcode\Search;
+namespace Minimalcode\Search\Tests;
 
+use Minimalcode\Search\Criteria;
 use PHPUnit_Framework_TestCase;
 
 abstract class CriteriaBaseTest extends PHPUnit_Framework_TestCase

--- a/tests/CriteriaReadmeTest.php
+++ b/tests/CriteriaReadmeTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Minimalcode\Search;
+namespace Minimalcode\Search\Tests;
 
 use DateTime;
+use Minimalcode\Search\Criteria;
 
 class CriteriaReadmeTest extends CriteriaBaseTest
 {

--- a/tests/CriteriaTest.php
+++ b/tests/CriteriaTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Minimalcode\Search;
+namespace Minimalcode\Search\Tests;
 
 use DateTime;
+use Minimalcode\Search\Criteria;
 
 class CriteriaTest extends CriteriaBaseTest
 {

--- a/tests/SpringCriteriaTest.php
+++ b/tests/SpringCriteriaTest.php
@@ -3,7 +3,6 @@
 namespace Minimalcode\Search\Tests;
 
 use Minimalcode\Search\Criteria;
-use Minimalcode\Search\CriteriaBaseTest;
 
 class SpringCriteriaTest extends CriteriaBaseTest
 {


### PR DESCRIPTION
This PR

* [x] fixes namespaces used in tests

💁‍♂️ What do you think about documenting it in `composer.json`?

```diff
diff --git a/composer.json b/composer.json
index a36b91b..3e7ebc2 100644
--- a/composer.json
+++ b/composer.json
@@ -22,5 +22,8 @@
   },
   "autoload": {
     "psr-4": { "Minimalcode\\Search\\": "src/" }
+  },
+  "autoload-dev": {
+    "psr-4": { "Minimalcode\\Search\\Tests\\": "tests/" }
   }
 }
``` 