### PR TITLE
Enhancement: Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+charset = utf-8
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.json]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.yml]
+indent_size = 2


### PR DESCRIPTION
This PR

* [x] adds an `.editorconfig` to the project

💁‍♂️ For reference, see http://editorconfig.org.

The primary reason for adding is inconsistent indentation in [`.travis.yml`](https://github.com/minimalcode-org/search/blob/3f5092763488986528c16f4e9088b82e824001cc/.travis.yml), which then would be a good idea to adjust. What do you think?

```diff
diff --git a/.travis.yml b/.travis.yml
index 5f5fb1a..6161398 100644
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: php

 php:
-    - 5.4
-    - 5.5
-    - 5.6
-    - 7.0
-    - nightly
-    - hhvm
+  - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
+  - nightly
+  - hhvm

 matrix:
   allow_failures:
```